### PR TITLE
[L-02] use msgSender function instead of msg.sender

### DIFF
--- a/contracts/Manageable.sol
+++ b/contracts/Manageable.sol
@@ -49,7 +49,7 @@ abstract contract Manageable is Ownable {
      */
     modifier onlySignerManager() {
         require(
-            _signerManager == msg.sender,
+            _signerManager == _msgSender(),
             "Manageable: caller is not the signer manager"
         );
         _;
@@ -60,7 +60,7 @@ abstract contract Manageable is Ownable {
      */
     modifier onlyGatewayManager() {
         require(
-            _gatewayManager == msg.sender,
+            _gatewayManager == _msgSender(),
             "Manageable: caller is not the gateway manager"
         );
         _;


### PR DESCRIPTION
Previously, it was [changed to msg.sender](https://github.com/CoinbaseStablecoin/coinbase-ens-contract/commit/f4ca190296a3c5bf5bb8c06ebd7636605401cd5f) when we bundled our own copy of Ownable, but now that reverted back to using OZ's Ownable, bring back the use of _msgSender() for consistency.