### PR TITLE
[N-08] fix: remove unused variable: _initialize

### DIFF
--- a/contracts/CoinbaseResolver.sol
+++ b/contracts/CoinbaseResolver.sol
@@ -16,7 +16,6 @@ import { IResolverService } from "./ens-offchain-resolver/IResolverService.sol";
 contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    bool private _initialized;
     string private _url;
     EnumerableSet.AddressSet private _signers;
 


### PR DESCRIPTION
`_initialized` is no longer used since upgradeability is removed