### PR TITLE
[L-04] Define x19 prefix as a constant

### DIFF
--- a/contracts/ens-offchain-resolver/SignatureVerifier.sol
+++ b/contracts/ens-offchain-resolver/SignatureVerifier.sol
@@ -7,6 +7,9 @@ pragma solidity 0.8.13;
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 library SignatureVerifier {
+    /// @dev Prefix with 0x1900 to prevent the preimage from being a valid ethereum transaction.
+    bytes2 private constant _PREIMAGE_PREFIX = 0x1900;
+
     /**
      * @dev Generates a hash for signing/verifying.
      * @param target: The address the signature is for.
@@ -22,7 +25,7 @@ library SignatureVerifier {
         return
             keccak256(
                 abi.encodePacked(
-                    hex"1900",
+                    _PREIMAGE_PREFIX,
                     target,
                     expires,
                     keccak256(request),


### PR DESCRIPTION
Removes this "magic number" and replace it with a constant to improve readability