### PR TITLE
[L-01] fix instances of incomplete documentation

### DIFF
--- a/contracts/CoinbaseResolver.sol
+++ b/contracts/CoinbaseResolver.sol
@@ -10,19 +10,33 @@ import { SignatureVerifier } from "./ens-offchain-resolver/SignatureVerifier.sol
 import { IResolverService } from "./ens-offchain-resolver/IResolverService.sol";
 
 /**
- * @notice Coinbase Offchain ENS Resolver
+ * @notice Coinbase Offchain ENS Resolver.
  * @dev Adapted from: https://github.com/ensdomains/offchain-resolver/blob/2bc616f19a94370828c35f29f71d5d4cab3a9a4f/packages/contracts/contracts/OffchainResolver.sol
  */
 contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     bool private _initialized;
+    /// @dev Gateway URL to use to perform offchain lookup.
     string private _url;
+    /// @dev Addresses for the set of signers.
     EnumerableSet.AddressSet private _signers;
 
+    /// @notice Event raised when a new gateway URL is set.
     event UrlSet(string indexed newUrl);
+    /// @notice Event raised when a new signer is added.
     event SignersAdded(address[] indexed addedSigners);
+    /// @notice Event raised when a signer is removed.
     event SignersRemoved(address[] indexed removedSigners);
+
+    /**
+     * @dev Error to raise when an offchain lookup is required.
+     * @param sender Sender address (address of this contract).
+     * @param urls URLs to request to perform the offchain lookup.
+     * @param callData Call data contains all the data to perform the offchain lookup.
+     * @param callbackFunction Callback function that should be called after lookup.
+     * @param extraData Optional extra data to send.
+     */
     error OffchainLookup(
         address sender,
         string[] urls,
@@ -33,11 +47,11 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
 
     /**
      * @notice Initializes the contract with the initial parameters.
-     * @param newOwner Owner address
-     * @param newSignerManager Signer manager address
-     * @param newGatewayManager Gateway manager address
-     * @param newUrl Gateway URL
-     * @param newSigners Signer addresses
+     * @param newOwner Owner address.
+     * @param newSignerManager Signer manager address.
+     * @param newGatewayManager Gateway manager address.
+     * @param newUrl Gateway URL.
+     * @param newSigners Signer addresses.
      */
     constructor(
         address newOwner,
@@ -55,7 +69,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
 
     /**
      * @notice Returns the gateway URL.
-     * @return Gateway URL
+     * @return Gateway URL.
      */
     function url() external view returns (string memory) {
         return _url;
@@ -63,7 +77,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
 
     /**
      * @notice Returns a list of signers.
-     * @return List of signers
+     * @return List of signers.
      */
     function signers() external view returns (address[] memory) {
         return _signers.values();
@@ -80,9 +94,8 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     /**
      * @notice Set the gateway URL.
      * @dev Can only be called by the gateway manager.
-     * @param newUrl New gateway URL
+     * @param newUrl New gateway URL.
      */
-
     function setUrl(string memory newUrl) external onlyGatewayManager {
         _setUrl(newUrl);
     }
@@ -90,7 +103,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     /**
      * @notice Add a set of new signers.
      * @dev Can only be called by the signer manager.
-     * @param signersToAdd Signer addresses
+     * @param signersToAdd Signer addresses.
      */
     function addSigners(address[] memory signersToAdd)
         external
@@ -101,8 +114,8 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
 
     /**
      * @notice Remove a set of existing signers.
-     * @dev Can only be called by the owner.
-     * @param signersToRemove Signer addresses
+     * @dev Can only be called by the signer manager.
+     * @param signersToRemove Signer addresses.
      */
     function removeSigners(address[] memory signersToRemove)
         external
@@ -115,8 +128,8 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     }
 
     /**
-     * @notice Support ERC-165 introspection
-     * @param interfaceID Interface ID
+     * @notice Support ERC-165 introspection.
+     * @param interfaceID Interface ID.
      * @return True if a given interface ID is supported.
      */
     function supportsInterface(bytes4 interfaceID)
@@ -133,9 +146,9 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     /**
      * @notice Initiate a resolution conforming to the ENSIP-10. Reverts with an
      * an OffchainLookup error.
-     * @param name DNS-encoded name to resolve
-     * @param data ABI-encoded data for the underlying resolution function (e.g. addr(bytes32), text(bytes32,string))
-     * @return Always reverts with an OffchainLookup error
+     * @param name DNS-encoded name to resolve.
+     * @param data ABI-encoded data for the underlying resolution function (e.g. addr(bytes32), text(bytes32,string)).
+     * @return Always reverts with an OffchainLookup error.
      */
     function resolve(bytes calldata name, bytes calldata data)
         external
@@ -162,9 +175,9 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     /**
      * @notice Callback used by CCIP-read compatible clients to verify and parse the response.
      * @dev Reverts if the signature is invalid.
-     * @param response ABI-encoded response data in the form of (bytes result, uint64 expires, bytes signature)
-     * @param extraData Original request data
-     * @return ABI-encoded result data for the underlying resolution function
+     * @param response ABI-encoded response data in the form of (bytes result, uint64 expires, bytes signature).
+     * @param extraData Original request data.
+     * @return ABI-encoded result data for the underlying resolution function.
      */
     function resolveWithProof(bytes calldata response, bytes calldata extraData)
         external
@@ -180,11 +193,11 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     }
 
     /**
-     * @notice Generates a hash for signing and verifying the offchain response
-     * @param expires Time at which the signature expires
-     * @param request Request data
-     * @param result Result data
-     * @return Hashed data for signing and verifying
+     * @notice Generates a hash for signing and verifying the offchain response.
+     * @param expires Time at which the signature expires.
+     * @param request Request data.
+     * @param result Result data.
+     * @return Hashed data for signing and verifying.
      */
     function makeSignatureHash(
         uint64 expires,
@@ -200,11 +213,19 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
             );
     }
 
+    /**
+     * @notice Sets the new gateway URL and emits a UrlSet event.
+     * @param newUrl New URL to be set.
+     */
     function _setUrl(string memory newUrl) private {
         _url = newUrl;
         emit UrlSet(newUrl);
     }
 
+    /**
+     * @notice Adds new signers and emits a SignersAdded event.
+     * @param signersToAdd List of addresses to add as signers.
+     */
     function _addSigners(address[] memory signersToAdd) private {
         for (uint256 i = 0; i < signersToAdd.length; i++) {
             _signers.add(signersToAdd[i]);

--- a/contracts/Manageable.sol
+++ b/contracts/Manageable.sol
@@ -15,14 +15,18 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
  * manager respectively.
  */
 abstract contract Manageable is Ownable {
+    /// @dev Address of the signer manager.
     address private _signerManager;
+    /// @dev Address of the gateway manager.
     address private _gatewayManager;
 
+    /// @notice Event raised when a signer manager is updated.
     event SignerManagerChanged(
         address indexed previousSignerManager,
         address indexed newSignerManager
     );
 
+    /// @notice Event raised when a gateway manager is updated.
     event GatewayManagerChanged(
         address indexed previousGatewayManager,
         address indexed newGatewayManager
@@ -68,7 +72,7 @@ abstract contract Manageable is Ownable {
 
     /**
      * @notice Change signer manager of the contract to a new account (`newSignerManager`).
-     * Can only be called by the current owner.
+     * @dev Can only be called by the current owner.
      * @param newSignerManager the new signer manager address.
      */
     function changeSignerManager(address newSignerManager)
@@ -85,7 +89,7 @@ abstract contract Manageable is Ownable {
 
     /**
      * @notice Change gateway manager of the contract to a new account (`newGatewayManager`).
-     * Can only be called by the current owner.
+     * @dev Can only be called by the current owner.
      * @param newGatewayManager the new gateway manager address.
      */
     function changeGatewayManager(address newGatewayManager)
@@ -101,8 +105,9 @@ abstract contract Manageable is Ownable {
     }
 
     /**
-     * @dev Change signer manager of the contract to a new account (`newSignerManager`).
-     * Internal function without access restriction.
+     * @notice Change signer manager of the contract to a new account (`newSignerManager`).
+     * @dev Internal function without access restriction.
+     * @param newSignerManager the new signer manager address.
      */
     function _changeSignerManager(address newSignerManager) internal virtual {
         address oldSignerManager = _signerManager;
@@ -111,8 +116,9 @@ abstract contract Manageable is Ownable {
     }
 
     /**
-     * @dev Change gateway manager of the contract to a new account (`newGatewayManager`).
-     * Internal function without access restriction.
+     * @notice Change gateway manager of the contract to a new account (`newGatewayManager`).
+     * @dev Internal function without access restriction.
+     * @param newGatewayManager the new gateway manager address.
      */
     function _changeGatewayManager(address newGatewayManager) internal virtual {
         address oldGatewayManager = _gatewayManager;

--- a/contracts/ens-offchain-resolver/IExtendedResolver.sol
+++ b/contracts/ens-offchain-resolver/IExtendedResolver.sol
@@ -3,6 +3,11 @@
 pragma solidity 0.8.13;
 
 interface IExtendedResolver {
+    /**
+     * @notice Function interface for the ENSIP-10 wildcard resolution function.
+     * @param name DNS-encoded name to resolve.
+     * @param data ABI-encoded data for the underlying resolution function (e.g. addr(bytes32), text(bytes32,string)).
+     */
     function resolve(bytes memory name, bytes memory data)
         external
         view

--- a/contracts/ens-offchain-resolver/IResolverService.sol
+++ b/contracts/ens-offchain-resolver/IResolverService.sol
@@ -3,6 +3,15 @@
 pragma solidity 0.8.13;
 
 interface IResolverService {
+    /**
+     * @notice Function interface for the lookup function supported by the off-chain gateway.
+     * @dev This function is executed off-chain by the off-chain gateway.
+     * @param name DNS-encoded name to resolve.
+     * @param data ABI-encoded data for the underlying resolution function (e.g. addr(bytes32), text(bytes32,string)).
+     * @return result ABI-encode result of the lookup.
+     * @return expires Time at which the signature expires.
+     * @return sig A signer's signature authenticating the result.
+     */
     function resolve(bytes calldata name, bytes calldata data)
         external
         view

--- a/contracts/ens-offchain-resolver/SignatureVerifier.sol
+++ b/contracts/ens-offchain-resolver/SignatureVerifier.sol
@@ -9,9 +9,11 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 library SignatureVerifier {
     /**
      * @dev Generates a hash for signing/verifying.
-     * @param target: The address the signature is for.
-     * @param request: The original request that was sent.
-     * @param result: The `result` field of the response (not including the signature part).
+     * @param target The address the signature is for.
+     * @param expires Time at which the signature expires.
+     * @param request The original request that was sent.
+     * @param result The `result` field of the response (not including the signature part).
+     * @return Hashed data for signing and verifying.
      */
     function makeSignatureHash(
         address target,
@@ -33,11 +35,11 @@ library SignatureVerifier {
 
     /**
      * @dev Verifies a signed message returned from a callback.
-     * @param request: The original request that was sent.
-     * @param response: An ABI encoded tuple of `(bytes result, uint64 expires, bytes sig)`, where `result` is the data to return
+     * @param request The original request that was sent.
+     * @param response An ABI encoded tuple of `(bytes result, uint64 expires, bytes sig)`, where `result` is the data to return
      *        to the caller, and `sig` is the (r,s,v) encoded message signature.
-     * @return signer: The address that signed this message.
-     * @return result: The `result` decoded from `response`.
+     * @return signer The address that signed this message.
+     * @return result The `result` decoded from `response`.
      */
     function verify(bytes calldata request, bytes calldata response)
         internal


### PR DESCRIPTION
- Fixes an incorrect inline documentation for `removeSigners`
- Adds missing NatSpec for CoinbaseResolver variables, events and errors and private functions
- Adds missing NatSpec for Manageable
- Adds missing NatSpec for IExtendedResolver
- Adds missing NatSpec for IResolverService contract