### PR TITLE
[N-01] Emit previousUrl and newUrl on urlSet event

### DIFF
--- a/contracts/CoinbaseResolver.sol
+++ b/contracts/CoinbaseResolver.sol
@@ -23,7 +23,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     EnumerableSet.AddressSet private _signers;
 
     /// @notice Event raised when a new gateway URL is set.
-    event UrlSet(string indexed newUrl);
+    event UrlSet(string indexed previousUrl, string indexed newUrl);
     /// @notice Event raised when a new signer is added.
     event SignersAdded(address[] indexed addedSigners);
     /// @notice Event raised when a signer is removed.
@@ -218,8 +218,9 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
      * @param newUrl New URL to be set.
      */
     function _setUrl(string memory newUrl) private {
+        string memory previousUrl = _url;
         _url = newUrl;
-        emit UrlSet(newUrl);
+        emit UrlSet(previousUrl, newUrl);
     }
 
     /**

--- a/test/CoinbaseResolver.test.ts
+++ b/test/CoinbaseResolver.test.ts
@@ -84,7 +84,8 @@ describe("CoinbaseResolver", () => {
   describe(".url/.setUrl", () => {
     it("lets the gateway manager change the gateway URL", async () => {
       await expect(resolver.connect(gatewayManager).setUrl("https://test.com"))
-        .not.to.be.reverted;
+        .to.emit(resolver, "UrlSet")
+        .withArgs(url, "https://test.com");
 
       expect(await resolver.url()).to.equal("https://test.com");
     });


### PR DESCRIPTION
To make our events more consistent send the previousUrl and the newUrl on the urlSet event.