### PR TITLE
[N-02] Gas optimizations

### DIFF
--- a/contracts/CoinbaseResolver.sol
+++ b/contracts/CoinbaseResolver.sol
@@ -96,7 +96,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
      * @dev Can only be called by the gateway manager.
      * @param newUrl New gateway URL.
      */
-    function setUrl(string memory newUrl) external onlyGatewayManager {
+    function setUrl(string calldata newUrl) external onlyGatewayManager {
         _setUrl(newUrl);
     }
 
@@ -105,7 +105,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
      * @dev Can only be called by the signer manager.
      * @param signersToAdd Signer addresses.
      */
-    function addSigners(address[] memory signersToAdd)
+    function addSigners(address[] calldata signersToAdd)
         external
         onlySignerManager
     {
@@ -117,11 +117,12 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
      * @dev Can only be called by the signer manager.
      * @param signersToRemove Signer addresses.
      */
-    function removeSigners(address[] memory signersToRemove)
+    function removeSigners(address[] calldata signersToRemove)
         external
         onlySignerManager
     {
-        for (uint256 i = 0; i < signersToRemove.length; i++) {
+        uint256 length = signersToRemove.length;
+        for (uint256 i = 0; i < length; i++) {
             _signers.remove(signersToRemove[i]);
         }
         emit SignersRemoved(signersToRemove);
@@ -201,8 +202,8 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
      */
     function makeSignatureHash(
         uint64 expires,
-        bytes memory request,
-        bytes memory result
+        bytes calldata request,
+        bytes calldata result
     ) external view returns (bytes32) {
         return
             SignatureVerifier.makeSignatureHash(
@@ -228,7 +229,8 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
      * @param signersToAdd List of addresses to add as signers.
      */
     function _addSigners(address[] memory signersToAdd) private {
-        for (uint256 i = 0; i < signersToAdd.length; i++) {
+        uint256 length = signersToAdd.length;
+        for (uint256 i = 0; i < length; i++) {
             _signers.add(signersToAdd[i]);
         }
         emit SignersAdded(signersToAdd);

--- a/contracts/ens-offchain-resolver/SignatureVerifier.sol
+++ b/contracts/ens-offchain-resolver/SignatureVerifier.sol
@@ -21,7 +21,7 @@ library SignatureVerifier {
     function makeSignatureHash(
         address target,
         uint64 expires,
-        bytes memory request,
+        bytes calldata request,
         bytes memory result
     ) internal pure returns (bytes32) {
         return
@@ -55,6 +55,11 @@ library SignatureVerifier {
             response,
             (bytes, uint64, bytes)
         );
+        require(
+            expires >= block.timestamp,
+            "SignatureVerifier: Signature expired"
+        );
+
         bytes32 sigHash = makeSignatureHash(
             address(this),
             expires,
@@ -63,10 +68,6 @@ library SignatureVerifier {
         );
 
         address signer = ECDSA.recover(sigHash, sig);
-        require(
-            expires >= block.timestamp,
-            "SignatureVerifier: Signature expired"
-        );
         return (signer, result);
     }
 }


### PR DESCRIPTION
Move timestamp validation earlier in function

Use calldata where possible

Use local variables where possible instead of reading from state