### PR TITLE
[N-03] Format revert messages consistently with Contract::function name

### DIFF
--- a/contracts/CoinbaseResolver.sol
+++ b/contracts/CoinbaseResolver.sol
@@ -189,7 +189,10 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
             extraData,
             response
         );
-        require(_signers.contains(signer), "invalid signature");
+        require(
+            _signers.contains(signer),
+            "CoinbaseResolver::resolveWithProof: invalid signature"
+        );
         return result;
     }
 

--- a/contracts/Manageable.sol
+++ b/contracts/Manageable.sol
@@ -54,7 +54,7 @@ abstract contract Manageable is Ownable {
     modifier onlySignerManager() {
         require(
             _signerManager == _msgSender(),
-            "Manageable: caller is not the signer manager"
+            "Manageable::onlySignerManager: caller is not signer manager"
         );
         _;
     }
@@ -65,7 +65,7 @@ abstract contract Manageable is Ownable {
     modifier onlyGatewayManager() {
         require(
             _gatewayManager == _msgSender(),
-            "Manageable: caller is not the gateway manager"
+            "Manageable::onlyGatewayManager: caller is not gateway manager"
         );
         _;
     }
@@ -82,7 +82,7 @@ abstract contract Manageable is Ownable {
     {
         require(
             newSignerManager != address(0),
-            "Manageable: new signer manager is the zero address"
+            "Manageable::changeSignerManager: manager is the zero address"
         );
         _changeSignerManager(newSignerManager);
     }
@@ -99,7 +99,7 @@ abstract contract Manageable is Ownable {
     {
         require(
             newGatewayManager != address(0),
-            "Manageable: new gateway manager is the zero address"
+            "Manageable::changeGatewayManager: manager is the zero address"
         );
         _changeGatewayManager(newGatewayManager);
     }

--- a/contracts/ens-offchain-resolver/SignatureVerifier.sol
+++ b/contracts/ens-offchain-resolver/SignatureVerifier.sol
@@ -57,7 +57,7 @@ library SignatureVerifier {
         );
         require(
             expires >= block.timestamp,
-            "SignatureVerifier: Signature expired"
+            "SignatureVerifier::verify: Signature expired"
         );
 
         bytes32 sigHash = makeSignatureHash(
@@ -68,6 +68,7 @@ library SignatureVerifier {
         );
 
         address signer = ECDSA.recover(sigHash, sig);
+
         return (signer, result);
     }
 }

--- a/test/CoinbaseResolver.test.ts
+++ b/test/CoinbaseResolver.test.ts
@@ -94,7 +94,9 @@ describe("CoinbaseResolver", () => {
       for (const account of [deployer, signerManager, signer, user, user2]) {
         await expect(
           resolver.connect(account).setUrl("https://test.com")
-        ).to.be.revertedWith("caller is not the gateway manager");
+        ).to.be.revertedWith(
+          "Manageable::onlyGatewayManager: caller is not gateway manager"
+        );
       }
     });
   });
@@ -138,10 +140,14 @@ describe("CoinbaseResolver", () => {
       for (const account of [deployer, gatewayManager, signer, user, user2]) {
         await expect(
           resolver.connect(account).addSigners([user2.address])
-        ).to.be.revertedWith("caller is not the signer manager");
+        ).to.be.revertedWith(
+          "Manageable::onlySignerManager: caller is not signer manager"
+        );
         await expect(
           resolver.connect(account).removeSigners([signer.address])
-        ).to.be.revertedWith("caller is not the signer manager");
+        ).to.be.revertedWith(
+          "Manageable::onlySignerManager: caller is not signer manager"
+        );
       }
     });
   });
@@ -213,7 +219,9 @@ describe("CoinbaseResolver", () => {
         resolver
           .connect(owner)
           .changeSignerManager(ethers.constants.AddressZero)
-      ).to.be.revertedWith("new signer manager is the zero address");
+      ).to.be.revertedWith(
+        "Manageable::changeSignerManager: manager is the zero address"
+      );
     });
   });
 
@@ -245,7 +253,9 @@ describe("CoinbaseResolver", () => {
         resolver
           .connect(owner)
           .changeGatewayManager(ethers.constants.AddressZero)
-      ).to.be.revertedWith("new gateway manager is the zero address");
+      ).to.be.revertedWith(
+        "Manageable::changeGatewayManager: manager is the zero address"
+      );
     });
   });
 


### PR DESCRIPTION
To favor readability and ease debugging, i have adapted all revert messages to the "Contract name::function name: error message" format.

This resulted in some of the error messages being quite long so i trimmed those to remove redundant information.
Example
`"Manageable: new signer manager is the zero address"`
was changed to 
`"Manageable::changeSignerManager: manager is the zero address"`
Since the function name says `changeSignerManager` theres no need to explicitly mention again that the issue relates to the `new signer manager` 