### PR TITLE
[N-06] Ensure signersAdded and signersRemoved emit accurate data

### DIFF
--- a/contracts/CoinbaseResolver.sol
+++ b/contracts/CoinbaseResolver.sol
@@ -109,7 +109,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
         onlySignerManager
     {
         for (uint256 i = 0; i < signersToRemove.length; i++) {
-            _signers.remove(signersToRemove[i]);
+            if (!_signers.remove(signersToRemove[i])) delete signersToRemove[i];
         }
         emit SignersRemoved(signersToRemove);
     }
@@ -207,7 +207,7 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
 
     function _addSigners(address[] memory signersToAdd) private {
         for (uint256 i = 0; i < signersToAdd.length; i++) {
-            _signers.add(signersToAdd[i]);
+            if (!_signers.add(signersToAdd[i])) delete signersToAdd[i];
         }
         emit SignersAdded(signersToAdd);
     }

--- a/test/CoinbaseResolver.test.ts
+++ b/test/CoinbaseResolver.test.ts
@@ -107,7 +107,7 @@ describe("CoinbaseResolver", () => {
       await expect(
         resolver
           .connect(signerManager)
-          .addSigners([user.address, user2.address])
+          .addSigners([user.address, user.address, user2.address])
       ).not.to.be.reverted;
 
       let signers = await resolver.signers();
@@ -121,7 +121,7 @@ describe("CoinbaseResolver", () => {
       await expect(
         resolver
           .connect(signerManager)
-          .removeSigners([user.address, user2.address])
+          .removeSigners([user.address, user.address, user2.address])
       ).not.to.be.reverted;
 
       signers = await resolver.signers();


### PR DESCRIPTION
If nothing is removed or added to the set then delete from the array to ensure that data emitted through the event is accurate