### PR TITLE
[L-03] Add a notice to let users know that an unexpired response can contain stale data

### DIFF
--- a/contracts/ens-offchain-resolver/SignatureVerifier.sol
+++ b/contracts/ens-offchain-resolver/SignatureVerifier.sol
@@ -32,6 +32,8 @@ library SignatureVerifier {
     }
 
     /**
+     * @notice A valid non-expired response can still contain stale data
+     * if the offchain data changes during the expiry duration before decoding the response.
      * @dev Verifies a signed message returned from a callback.
      * @param request: The original request that was sent.
      * @param response: An ABI encoded tuple of `(bytes result, uint64 expires, bytes sig)`, where `result` is the data to return


### PR DESCRIPTION
Add a notice to let users know that a valid non-expired response can still contain data depending on the duration of the expiry