### PR TITLE
N-06 Ensure addSigners and removeSigners emit accurate data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 INFURA_API_KEY=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
-MNEMONIC=here is where your twelve words mnemonic should be put my friend
+MNEMONIC="put your mnemonic recovery phrase here"
+ETHERSCAN_API_KEY="enter your etherscan api key"
+PRIVATE_KEY="enter a loose private key if you prefer to use that instead of the mnemonic"

--- a/contracts/CoinbaseResolver.sol
+++ b/contracts/CoinbaseResolver.sol
@@ -21,8 +21,8 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
     EnumerableSet.AddressSet private _signers;
 
     event UrlSet(string indexed newUrl);
-    event SignersAdded(address[] indexed addedSigners);
-    event SignersRemoved(address[] indexed removedSigners);
+    event SignerAdded(address indexed addedSigner);
+    event SignerRemoved(address indexed removedSigner);
     error OffchainLookup(
         address sender,
         string[] urls,
@@ -109,9 +109,11 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
         onlySignerManager
     {
         for (uint256 i = 0; i < signersToRemove.length; i++) {
-            _signers.remove(signersToRemove[i]);
+            address signer = signersToRemove[i];
+            if (_signers.remove(signer)) {
+                emit SignerRemoved(signer);
+            }
         }
-        emit SignersRemoved(signersToRemove);
     }
 
     /**
@@ -207,8 +209,10 @@ contract CoinbaseResolver is ERC165, Manageable, IExtendedResolver {
 
     function _addSigners(address[] memory signersToAdd) private {
         for (uint256 i = 0; i < signersToAdd.length; i++) {
-            _signers.add(signersToAdd[i]);
+            address signer = signersToAdd[i];
+            if (_signers.add(signersToAdd[i])) {
+                emit SignerAdded(signer);
+            }
         }
-        emit SignersAdded(signersToAdd);
     }
 }

--- a/test/CoinbaseResolver.test.ts
+++ b/test/CoinbaseResolver.test.ts
@@ -105,10 +105,17 @@ describe("CoinbaseResolver", () => {
       }
 
       await expect(
-        resolver
-          .connect(signerManager)
-          .addSigners([user.address, user2.address])
-      ).not.to.be.reverted;
+        resolver.connect(signerManager).addSigners([
+          user.address,
+          user.address, // duplicate address is ignored
+          user2.address,
+          signer.address, // existing signer address is ignored
+        ])
+      )
+        .to.emit(resolver, "SignerAdded")
+        .withArgs(user.address)
+        .and.to.emit(resolver, "SignerAdded")
+        .withArgs(user2.address);
 
       let signers = await resolver.signers();
       expect(signers).to.have.lengthOf(3);
@@ -119,10 +126,17 @@ describe("CoinbaseResolver", () => {
       }
 
       await expect(
-        resolver
-          .connect(signerManager)
-          .removeSigners([user.address, user2.address])
-      ).not.to.be.reverted;
+        resolver.connect(signerManager).removeSigners([
+          user.address,
+          user.address, // duplicate address is ignored
+          user2.address,
+          owner.address, // non-signer address is ignored
+        ])
+      )
+        .to.emit(resolver, "SignerRemoved")
+        .withArgs(user.address)
+        .and.to.emit(resolver, "SignerRemoved")
+        .withArgs(user2.address);
 
       signers = await resolver.signers();
       expect(signers).to.eql([signer.address]);


### PR DESCRIPTION
`SignerAdded` and `SignerRemoved` events are emitted only for addresses that are actually added or removed.

Also changed the event not to use an array as many popular client libraries don't support arrays in events (e.g. `ethers`)